### PR TITLE
在要执行的sql中给表名和字段名加上`，遇到跟MySQL关键字相同的时候不会报错。如果jdbc.tablePrefix设置为空的话，会产生跟关键字相同的冲突。

### DIFF
--- a/latke-core/src/main/java/org/b3log/latke/repository/jdbc/JdbcRepository.java
+++ b/latke-core/src/main/java/org/b3log/latke/repository/jdbc/JdbcRepository.java
@@ -223,7 +223,7 @@ public final class JdbcRepository implements Repository {
             }
         }
 
-        sql.append("INSERT INTO ").append(getName()).append(insertString).append(" VALUES ").append(wildcardString);
+        sql.append("INSERT INTO ").append("`" + getName() + "`").append(insertString).append(" VALUES ").append(wildcardString);
     }
 
     @Override
@@ -298,7 +298,7 @@ public final class JdbcRepository implements Repository {
             paramList.add(needUpdateJsonObject.get(key));
         }
 
-        sqlBuilder.append("UPDATE ").append(getName()).append(propertyBuilder).append(" WHERE ").append(JdbcRepositories.getDefaultKeyName()).append(" = ?");
+        sqlBuilder.append("UPDATE ").append("`" + getName() + "`").append(propertyBuilder).append(" WHERE ").append(JdbcRepositories.getDefaultKeyName()).append(" = ?");
         paramList.add(id);
     }
 
@@ -351,7 +351,7 @@ public final class JdbcRepository implements Repository {
         final Connection connection = getConnection();
 
         try {
-            sql.append("DELETE FROM ").append(getName()).append(" WHERE ").append(JdbcRepositories.getDefaultKeyName()).append(" = '").append(id).append("'");
+            sql.append("DELETE FROM ").append("`" + getName() + "`").append(" WHERE ").append(JdbcRepositories.getDefaultKeyName()).append(" = '").append(id).append("'");
             JdbcUtil.executeSql(sql.toString(), connection, debug);
         } catch (final Exception e) {
             LOGGER.log(Level.ERROR, "Remove failed", e);
@@ -362,7 +362,7 @@ public final class JdbcRepository implements Repository {
 
     @Override
     public void remove(final Query query) throws RepositoryException {
-        final StringBuilder deleteSQL = new StringBuilder("DELETE FROM ").append(getName());
+        final StringBuilder deleteSQL = new StringBuilder("DELETE FROM ").append("`" + getName() + "`");
 
         final List<Object> paramList = new ArrayList<>();
         final StringBuilder filterSql = new StringBuilder();
@@ -389,7 +389,7 @@ public final class JdbcRepository implements Repository {
         final Connection connection = getConnection();
 
         try {
-            sql.append("SELECT * FROM ").append(getName()).append(" WHERE ").append(JdbcRepositories.getDefaultKeyName()).append(" = ?");
+            sql.append("SELECT * FROM ").append("`" + getName() + "`").append(" WHERE ").append(JdbcRepositories.getDefaultKeyName()).append(" = ?");
             final ArrayList<Object> paramList = new ArrayList<>();
             paramList.add(id);
             ret = JdbcUtil.queryJsonObject(sql.toString(), paramList, connection, getName(), debug);
@@ -514,7 +514,7 @@ public final class JdbcRepository implements Repository {
         buildOrderBy(orderByBuilder, query.getSorts());
 
         if (-1 == pageCount) {
-            final StringBuilder countBuilder = new StringBuilder("SELECT COUNT(" + JdbcRepositories.getDefaultKeyName() + ") FROM ").append(getName());
+            final StringBuilder countBuilder = new StringBuilder("SELECT COUNT(" + JdbcRepositories.getDefaultKeyName() + ") FROM ").append("`" + getName() + "`");
             if (StringUtils.isNotBlank(whereBuilder.toString())) {
                 countBuilder.append(" WHERE ").append(whereBuilder);
             }
@@ -642,14 +642,14 @@ public final class JdbcRepository implements Repository {
 
     @Override
     public long count() throws RepositoryException {
-        final StringBuilder sql = new StringBuilder("SELECT COUNT(" + JdbcRepositories.getDefaultKeyName() + ") FROM ").append(getName());
+        final StringBuilder sql = new StringBuilder("SELECT COUNT(" + JdbcRepositories.getDefaultKeyName() + ") FROM ").append("`" + getName() + "`");
 
         return count(sql, new ArrayList<>());
     }
 
     @Override
     public long count(final Query query) throws RepositoryException {
-        final StringBuilder countSql = new StringBuilder("SELECT COUNT(" + JdbcRepositories.getDefaultKeyName() + ") FROM ").append(getName());
+        final StringBuilder countSql = new StringBuilder("SELECT COUNT(" + JdbcRepositories.getDefaultKeyName() + ") FROM ").append("`" + getName() + "`");
 
         final List<Object> paramList = new ArrayList<>();
         final StringBuilder filterSql = new StringBuilder();

--- a/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/BooleanMapping.java
+++ b/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/BooleanMapping.java
@@ -36,7 +36,7 @@ public class BooleanMapping implements Mapping {
     public String toDataBaseSting(final FieldDefinition definition) {
         final StringBuilder sql = new StringBuilder();
 
-        sql.append(definition.getName());
+        sql.append("`").append(definition.getName()).append("`");
         sql.append(" char(1)");
         if (!definition.getNullable()) {
             sql.append(" not null");

--- a/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/DateMapping.java
+++ b/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/DateMapping.java
@@ -33,8 +33,9 @@ public final class DateMapping implements Mapping {
 
     @Override
     public String toDataBaseSting(final FieldDefinition definition) {
-        final StringBuilder builder = new StringBuilder(definition.getName()).append(" datetime");
+        final StringBuilder builder = new StringBuilder();
 
+        builder.append("`").append(definition.getName()).append("` datetime");
         if (!definition.getNullable()) {
             builder.append(" not null");
         }

--- a/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/IntMapping.java
+++ b/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/IntMapping.java
@@ -32,7 +32,7 @@ public class IntMapping implements Mapping {
 
         final StringBuilder sql = new StringBuilder();
 
-        sql.append(definition.getName());
+        sql.append("`").append(definition.getName()).append("`");
         sql.append(" int");
         if (!definition.getNullable()) {
             sql.append(" not null");

--- a/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/LongMapping.java
+++ b/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/LongMapping.java
@@ -33,8 +33,9 @@ public final class LongMapping implements Mapping {
 
     @Override
     public String toDataBaseSting(final FieldDefinition definition) {
-        final StringBuilder builder = new StringBuilder(definition.getName()).append(" bigint");
+        final StringBuilder builder = new StringBuilder();
 
+        builder.append("`").append(definition.getName()).append("` bigint");
         if (!definition.getNullable()) {
             builder.append(" not null");
         }

--- a/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/NumberMapping.java
+++ b/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/NumberMapping.java
@@ -32,7 +32,7 @@ public class NumberMapping implements Mapping {
 
         final StringBuilder sql = new StringBuilder();
 
-        sql.append(definition.getName());
+        sql.append("`").append(definition.getName()).append("`");
         sql.append("  double ");
         if (!definition.getNullable()) {
             sql.append(" not null");

--- a/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/StringMapping.java
+++ b/latke-core/src/main/java/org/b3log/latke/repository/jdbc/mapping/StringMapping.java
@@ -31,7 +31,7 @@ public class StringMapping implements Mapping {
     @Override
     public String toDataBaseSting(final FieldDefinition definition) {
         final StringBuilder sql = new StringBuilder();
-        sql.append(definition.getName());
+        sql.append("`").append(definition.getName()).append("`");
         if (null == definition.getLength()) {
             definition.setLength(0);
         }

--- a/latke-repository-mysql/src/main/java/org/b3log/latke/repository/mysql/MysqlJdbcDatabaseSolution.java
+++ b/latke-repository-mysql/src/main/java/org/b3log/latke/repository/mysql/MysqlJdbcDatabaseSolution.java
@@ -80,7 +80,7 @@ public class MysqlJdbcDatabaseSolution extends AbstractJdbcDatabaseSolution {
                             final String tableName) {
         final StringBuilder sql = new StringBuilder();
 
-        sql.append(selectSql).append(" FROM ").append(tableName);
+        sql.append(selectSql).append(" FROM ").append("`" + tableName + "`");
         if (StringUtils.isNotBlank(filterSql)) {
             sql.append(" WHERE ").append(filterSql);
         }
@@ -92,14 +92,14 @@ public class MysqlJdbcDatabaseSolution extends AbstractJdbcDatabaseSolution {
     @Override
     public String getRandomlySql(final String tableName, final int fetchSize) {
         final StringBuilder sql = new StringBuilder();
-        sql.append("SELECT * FROM ").append(tableName).append(" ORDER BY RAND() LIMIT ").append(fetchSize);
+        sql.append("SELECT * FROM ").append("`" + tableName + "`").append(" ORDER BY RAND() LIMIT ").append(fetchSize);
 
         return sql.toString();
     }
 
     @Override
     protected void createTableHead(final StringBuilder createTableSql, final RepositoryDefinition repositoryDefinition) {
-        createTableSql.append("CREATE TABLE IF NOT EXISTS ").append(repositoryDefinition.getName()).append("(");
+        createTableSql.append("CREATE TABLE IF NOT EXISTS `").append(repositoryDefinition.getName()).append("`(");
     }
 
     @Override


### PR DESCRIPTION
* PR 修复缺陷请先开 issue 报告缺陷
* PR 提交新特性请先到[黑客派](https://hacpai.com)发帖讨论
* PR 请提交到开发分支上
* 我们对编码风格有着较为严格的要求，请在阅读代码后模仿类似风格提交
