### PR TITLE
Support Netty native transports for better performance.

### DIFF
--- a/latke-core/pom.xml
+++ b/latke-core/pom.xml
@@ -30,6 +30,18 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <classifier>osx-x86_64</classifier>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,20 @@
             </dependency>
 
             <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+                <classifier>linux-x86_64</classifier>
+            </dependency>
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-kqueue</artifactId>
+                <version>${netty.version}</version>
+                <classifier>osx-x86_64</classifier>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
                 <version>${tika.version}</version>


### PR DESCRIPTION
Netty support platform-specifc native transports using epoll/kqueue, which are expected to lead to better performance than NIO, as said in the [official documentation](https://github.com/netty/netty/wiki/Native-transports).

We should use them whenever possible, and only use NIO based transport as fallback option.