### PR TITLE
:bug: fix bug

### DIFF
--- a/latke-core/src/main/java/org/b3log/latke/util/CollectionUtils.java
+++ b/latke-core/src/main/java/org/b3log/latke/util/CollectionUtils.java
@@ -148,7 +148,8 @@ public final class CollectionUtils {
      */
     @SuppressWarnings("unchecked")
     public static <T> T[] jsonArrayToArray(final JSONArray jsonArray, final Class<? extends T[]> newType) {
-        return (T[]) Optional.ofNullable(jsonArray)
+        Object[] result = Optional.ofNullable(jsonArray)
                 .map(JSONArray::toList).map(List::toArray).orElse(new Object[]{});
+        return Arrays.copyOf(result, result.length, newType);
     }
 }


### PR DESCRIPTION
Array of objects should be casted with `Arrays.copyOf()` instead of direct cast.

Sorry for the bug in my last PR.